### PR TITLE
Support Java 11 by backporting IntBuffer.slice(int, int)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>13</source>
-					<target>13</target>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/de/kherud/llama/SliceableIntBuffer.java
+++ b/src/main/java/de/kherud/llama/SliceableIntBuffer.java
@@ -11,26 +11,26 @@ import java.nio.IntBuffer;
  * Does not implement Buffer because the {@link java.nio.Buffer#slice(int, int)}
  * method is specifically blocked from being implemented or used on older jdk versions.
  */
-public class SliceableIntBuffer {
-	public final IntBuffer delegate;
+class SliceableIntBuffer {
+	final IntBuffer delegate;
 
 	private final int offset;
 
 	private final int capacity;
 
-	public SliceableIntBuffer(IntBuffer delegate) {
+	SliceableIntBuffer(IntBuffer delegate) {
 		this.delegate = delegate;
 		this.capacity = delegate.capacity();
 		this.offset = 0;
 	}
 
-	public SliceableIntBuffer(IntBuffer delegate, int offset, int capacity) {
+	SliceableIntBuffer(IntBuffer delegate, int offset, int capacity) {
 		this.delegate = delegate;
 		this.offset = offset;
 		this.capacity = capacity;
 	}
 
-	public SliceableIntBuffer slice(int offset, int length) {
+	SliceableIntBuffer slice(int offset, int length) {
 		// Where the magic happens
 		// Wrapping is equivalent to the slice operation so long
 		// as you keep track of your offsets and capacities.
@@ -48,20 +48,20 @@ public class SliceableIntBuffer {
 
 	}
 
-	public int capacity() {
+	int capacity() {
 		return capacity;
 	}
 
-	public SliceableIntBuffer put(int index, int i) {
+	SliceableIntBuffer put(int index, int i) {
 		delegate.put(offset + index, i);
 		return this;
 	}
 
-	public int get(int index) {
+	int get(int index) {
 		return delegate.get(offset + index);
 	}
 
-	public void clear() {
+	void clear() {
 		// Clear set the limit and position
 		// to 0 and capacity respectively,
 		// but that's not what the buffer was initially
@@ -72,6 +72,5 @@ public class SliceableIntBuffer {
 		delegate.limit(offset + capacity);
 		delegate.position(offset);
 	}
-
 
 }

--- a/src/main/java/de/kherud/llama/SliceableIntBuffer.java
+++ b/src/main/java/de/kherud/llama/SliceableIntBuffer.java
@@ -1,0 +1,77 @@
+package de.kherud.llama;
+
+import java.nio.IntBuffer;
+
+
+/**
+ * Container that allows slicing an {@link IntBuffer}
+ * with arbitrary slicing lengths on Java versions older than 13.
+ * Does not extend IntBuffer because the super constructor
+ * requires memory segment proxies, and we can't access the delegate's.
+ * Does not implement Buffer because the {@link java.nio.Buffer#slice(int, int)}
+ * method is specifically blocked from being implemented or used on older jdk versions.
+ */
+public class SliceableIntBuffer {
+	public final IntBuffer delegate;
+
+	private final int offset;
+
+	private final int capacity;
+
+	public SliceableIntBuffer(IntBuffer delegate) {
+		this.delegate = delegate;
+		this.capacity = delegate.capacity();
+		this.offset = 0;
+	}
+
+	public SliceableIntBuffer(IntBuffer delegate, int offset, int capacity) {
+		this.delegate = delegate;
+		this.offset = offset;
+		this.capacity = capacity;
+	}
+
+	public SliceableIntBuffer slice(int offset, int length) {
+		// Where the magic happens
+		// Wrapping is equivalent to the slice operation so long
+		// as you keep track of your offsets and capacities.
+		// So, we use this container class to track those offsets and translate
+		// them to the correct frame of reference.
+		return new SliceableIntBuffer(
+				IntBuffer.wrap(
+						this.delegate.array(),
+						this.offset + offset,
+						length
+				),
+				this.offset + offset,
+				length
+		);
+
+	}
+
+	public int capacity() {
+		return capacity;
+	}
+
+	public SliceableIntBuffer put(int index, int i) {
+		delegate.put(offset + index, i);
+		return this;
+	}
+
+	public int get(int index) {
+		return delegate.get(offset + index);
+	}
+
+	public void clear() {
+		// Clear set the limit and position
+		// to 0 and capacity respectively,
+		// but that's not what the buffer was initially
+		// after the wrap() call, so we manually
+		// set the limit and position to what they were
+		// after the wrap call.
+		delegate.clear();
+		delegate.limit(offset + capacity);
+		delegate.position(offset);
+	}
+
+
+}


### PR DESCRIPTION
This PR lowers the source and target JDK versions to JDK 11, fixing the missing `IntBuffer#slice(int, int)` method by creating a custom implementation and container class. My original intention was to extend IntBuffer, but the super constructor requires a bunch of parameters that I can't pull from the delegate