### PR TITLE
Fix linux ARM64 Github builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,15 +14,22 @@ jobs:
           - {
             name: Linux,
             arch: x86_64,
+            docker-arch: linux/amd64,
+            docker-image: eclipse-temurin:11,
             image: ubuntu-latest,
             cmake: "-DCMAKE_CXX_FLAGS='-march=x86-64'"
           }
-          #          - {
-          #            name: Linux,
-          #            arch: aarch64,
-          #            image: ubuntu-latest,
-          #            cmake: "-DCMAKE_CXX_FLAGS='-march=armv8-a'"
-          #          }
+          - {
+            # Sure do love the many ways to refer to ARM 64 bit
+            # The platform passed to docker must be linux/arm64 to pull in the right image
+            # But then we need aarch64 for the CMake invocation. Maybe we can switch CMake to using arm64?
+            name: Linux,
+            docker-arch: linux/arm64,
+            docker-image: eclipse-temurin:11,
+            arch: aarch64,
+            image: ubuntu-latest,
+            cmake: "-DCMAKE_CXX_FLAGS='-march=armv8-a'"
+          }
           - {
             name: Mac,
             arch: x86_64,
@@ -52,23 +59,41 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Set up QEMU
+        if: ${{ matrix.target.name == 'Linux' }}
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: ${{ matrix.target.docker-arch }}
       - name: CMake (Windows)
         if: ${{ matrix.target.name == 'Windows' }}
         shell: cmd
         run: |
           cd scripts && .\build.bat ${{ matrix.target.cmake }} -DOS_NAME=${{ matrix.target.name }} -DOS_ARCH=${{ matrix.target.arch }}
-      - name: CMake (Unix)
-        if: ${{ matrix.target.name != 'Windows' }}
+      - name: CMake (Linux)
+        if: ${{ matrix.target.name == 'Linux' }}
+        run: |
+          docker run \
+            --rm \
+            -v $(pwd):/${{ github.workspace }} \
+            -w ${{ github.workspace }} \
+            --platform ${{ matrix.target.docker-arch }} \
+            ${{ matrix.target.docker-image }} \
+            sh -c "apt-get update && apt-get install -y cmake openjdk-11-jdk git build-essential && cd scripts && ./build.sh ${{ matrix.target.cmake }} -DOS_NAME=${{ matrix.target.name }} -DOS_ARCH=${{ matrix.target.arch }}"
+            # The above apt-get commands can be moved to a Dockerfile, but then
+            # the image needs to be built for the docker-arch architecture,
+            # which means using the docker/setup-buildx-action
+      - name: CMake (Mac)
+        if: ${{ matrix.target.name == 'Mac' }}
         shell: bash
         run: |
           cd scripts && ./build.sh ${{ matrix.target.cmake }} -DOS_NAME=${{ matrix.target.name }} -DOS_ARCH=${{ matrix.target.arch }}
-      - name: Upload Unix Artifact
+      - name: Upload Windows Artifact
         if: ${{ matrix.target.name == 'Windows' }}
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
           path: ${{ github.workspace }}\src\main\resources\de\kherud\llama\
-      - name: Upload Windows Artifact
+      - name: Upload Unix Artifact
         if: ${{ matrix.target.name != 'Windows' }}
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This PR fixes the builds for linux ARM64, allowing Github Actions to build the arm libs and include them with the other included libraries.

#### Notes
Getting this to work was quite the struggle, so I figured I'd write down notes on what I discovered along the journey.

1. Github does not yet host ARM runners. This was the first major hurdle, as it meant we couldn't use the documented container option
2.  Dedicated actions like [arm-runner-action](https://github.com/pguyot/arm-runner-action) were almost universally abandoned or in some way broken
3. I finally took inspiration from [whisper-jni's workflow](https://github.com/GiviMAD/whisper-jni/blob/main/.github/workflows/main.yml) and used docker in combination with `qemu` architecture emulation
4. Getting docker to pull the right image was a true exercise in anger management. I have no idea why, but using the `arm64` platform used in the above-linked workflow did not work to pull a pre-built image. I needed to use `linux/arm64v8` for some images, `linux/arm64/v8` for others, and finally `linux/arm64` for the image I settled on
5. Speaking of images, figuring out which images supported both amd64 and arm64 was also a nightmare. I had wanted to use the same image that whisper-jni used as a base, `maven:3.9.3-eclipse-temurin-17-focal`, but no matter what combination of parameters I chose Docker would always pull the amd64 image. With other images, if the selected platform did not have an image it would just error out, so no idea why it was doing that
6. Even when running the amd64 maven image, CMake failed because `gcc` could not compile a test binary during the configure stage. No idea why, no information on the error whatsoever
7. I eventually settled on `eclipse-temurin:11`. It's the only image I've managed to find that supports both amd64 and arm64, doesn't have that weird compiler issue, and has the `jni.h` on the include path (another problem with images)
8. Testing the workflow locally using [act](https://github.com/nektos/act) finally produced a full arm64 library
9. However, running with all platforms in the matrix enabled caused issues with CMake, because the build cache is shared and it stores the platform architecture in the cache (why does CMake always do the stupidest things?). This resulted in CMake trying to build an x86 image while running inside an arm64 container, blowing up immediately. This issue has not been fixed because I believe it's a consequence of using Act specifically