### PR TITLE
Upgrade llama.cpp to most recent release (b1645) so it supports mixtral

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Make sure everything works by running
 g++ -v  # depending on your compiler
 java -version
 mvn -v
-echo $JAVA_HOME # for inlux/macos
+echo $JAVA_HOME # for linux/macos
 echo %JAVA_HOME% # for windows
 ```
 

--- a/build-args.cmake
+++ b/build-args.cmake
@@ -55,7 +55,6 @@ option(LLAMA_CLBLAST                         "llama: use CLBlast"               
 option(LLAMA_METAL                           "llama: use Metal"                                 ${LLAMA_METAL_DEFAULT})
 option(LLAMA_METAL_NDEBUG                    "llama: disable Metal debugging"                   OFF)
 option(LLAMA_MPI                             "llama: use MPI"                                   OFF)
-option(LLAMA_K_QUANTS                        "llama: use k-quants"                              ON)
 option(LLAMA_QKK_64                          "llama: use super-block size of 64 for k-quants"   OFF)
 
 option(LLAMA_BUILD_TESTS                "llama: build tests"    ${LLAMA_STANDALONE})
@@ -200,15 +199,6 @@ if (LLAMA_BLAS)
         message(WARNING "BLAS not found, please refer to "
         "https://cmake.org/cmake/help/latest/module/FindBLAS.html#blas-lapack-vendors"
         " to set correct LLAMA_BLAS_VENDOR")
-    endif()
-endif()
-
-if (LLAMA_K_QUANTS)
-    set(GGML_HEADERS_EXTRA k_quants.h)
-    set(GGML_SOURCES_EXTRA k_quants.c)
-    add_compile_definitions(GGML_USE_K_QUANTS)
-    if (LLAMA_QKK_64)
-        add_compile_definitions(GGML_QKK_64)
     endif()
 endif()
 

--- a/build-args.cmake
+++ b/build-args.cmake
@@ -202,6 +202,10 @@ if (LLAMA_BLAS)
     endif()
 endif()
 
+if (LLAMA_QKK_64)
+    add_compile_definitions(GGML_QKK_64)
+endif()
+
 if (LLAMA_CUBLAS)
     cmake_minimum_required(VERSION 3.17)
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,15 @@
 					</compilerArgs>
 				</configuration>
 			</plugin>
+			<!-- This allows us to execute the examples from the command line -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>3.0.0</version>
+				<configuration>
+					<classpathScope>test</classpathScope>
+				</configuration>
+			</plugin>
 
 			<!-- Surefire plugin for unit tests -->
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,10 @@
 	<properties>
 		<jna.version>5.13.0</jna.version>
 		<junit.version>4.13.1</junit.version>
+		<test.plugin.version>3.2.3</test.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<integration.test.model>mistral-7b-instruct-v0.2.Q5_K_S.gguf</integration.test.model>
+		<integration.test.model.url>https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/${integration.test.model}</integration.test.model.url>
 	</properties>
 
 	<dependencies>
@@ -76,6 +79,72 @@
 						<arg>src/main/cpp</arg>
 					</compilerArgs>
 				</configuration>
+			</plugin>
+
+			<!-- Surefire plugin for unit tests -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${test.plugin.version}</version>
+				<configuration>
+
+				</configuration>
+			</plugin>
+
+			<!-- Failsafe plugin for integration tests -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${test.plugin.version}</version>
+				<configuration>
+					<!-- Integration Tests need a model home variable -->
+					<systemPropertyVariables>
+						<propertyName>model.home</propertyName>
+						<integration.test.model>${integration.test.model}</integration.test.model>
+					</systemPropertyVariables>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<id>Download the integration test model if it doesn't exist</id>
+						<phase>pre-integration-test</phase>
+						<configuration>
+							<target>
+								<!-- Check if the system property is set -->
+								<condition property="isModelHomeSet" value="true">
+									<isset property="model.home"/>
+								</condition>
+
+								<!-- Fail the build if the property is not set -->
+								<fail message="The 'model.home' system property is not set." unless="isModelHomeSet"/>
+
+								<!-- Define the file path using the system property -->
+								<property name="modelPath" value="${model.home}${file.separator}${integration.test.model}"/>
+
+								<!-- Check if the file exists -->
+								<available file="${modelPath}" property="fileExists"/>
+
+								<!-- Download the file if it doesn't exist -->
+								<get src="${integration.test.model.url}" dest="${modelPath}" skipexisting="true"/>
+							</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
 
 								<!-- Fail the build if the property is not set -->
 								<fail message="The 'model.home' system property is not set." unless="isModelHomeSet"/>
+								<!-- Check if the directory exists -->
+								<available file="${model.home}" type="dir" property="model.home.exists"/>
+
+								<!-- Fail the build if the directory does not exist -->
+								<fail message="Model home directory does not exist: ${model.home}" unless="model.home.exists"/>
 
 								<!-- Define the file path using the system property -->
 								<property name="modelPath" value="${model.home}${file.separator}${integration.test.model}"/>

--- a/src/test/java/de/kherud/llama/LlamaModelIT.java
+++ b/src/test/java/de/kherud/llama/LlamaModelIT.java
@@ -11,8 +11,6 @@ import org.junit.Test;
 
 public class LlamaModelIT {
 
-	public static final String MODEL_HOME_PROPERTY = "model.home";
-	public static final String MODEL_NAME_PROPERTY = "integration.test.model";
 	private static final String prefix = "def remove_non_ascii(s: str) -> str:\n    \"\"\" ";
 	private static final String suffix = "\n    return result\n";
 	private static String logOutput = "";
@@ -22,21 +20,9 @@ public class LlamaModelIT {
 	@BeforeClass
 	public static void setup() {
 		LlamaModel.setLogger((level, msg) -> logOutput += msg);
-		String modelHome = System.getProperty(MODEL_HOME_PROPERTY);
-		String modelName= System.getProperty(MODEL_NAME_PROPERTY);
-		if(modelHome == null) {
-			throw new RuntimeException("Please pass the system property \"" + MODEL_HOME_PROPERTY + "\" to the test. "
-					+ "This should represent the location on local disk where your models are located. "
-					+ "If you are running this via maven, please run with a -Dmodel.home=/path/to/model/dir. "
-					+ "Make sure that the directory that you pass exists.");
-		}
-		if(modelName == null) {
-			throw new RuntimeException("The system property \"" + MODEL_NAME_PROPERTY + "\" is not set.  If you are running this from an IDE, please set it.  If you are running this from Maven, this should be set automatically and there is something strange going on." );
-		}
-		String modelPath= Paths.get(modelHome, modelName).toString();
 		ModelParameters params = new ModelParameters().setNGpuLayers(43).setEmbedding(true);
 		model =
-				new LlamaModel(modelPath, params);
+				new LlamaModel(ModelResolver.getPathToITModel(), params);
 	}
 
 	@AfterClass

--- a/src/test/java/de/kherud/llama/LlamaModelIT.java
+++ b/src/test/java/de/kherud/llama/LlamaModelIT.java
@@ -22,8 +22,7 @@ public class LlamaModelIT {
 		ModelParameters params = new ModelParameters()
 				.setNGpuLayers(43)
 				.setEmbedding(true);
-		model =
-				new LlamaModel(ModelResolver.getPathToITModel(), params);
+		model = new LlamaModel(ModelResolver.getPathToITModel(), params);
 	}
 
 	@AfterClass

--- a/src/test/java/de/kherud/llama/LlamaModelIT.java
+++ b/src/test/java/de/kherud/llama/LlamaModelIT.java
@@ -25,7 +25,10 @@ public class LlamaModelIT {
 		String modelHome = System.getProperty(MODEL_HOME_PROPERTY);
 		String modelName= System.getProperty(MODEL_NAME_PROPERTY);
 		if(modelHome == null) {
-			throw new RuntimeException("Please pass the system property \"" + MODEL_HOME_PROPERTY + "\" to the test.  This should represent the location on local disk where your models are located.");
+			throw new RuntimeException("Please pass the system property \"" + MODEL_HOME_PROPERTY + "\" to the test. "
+					+ "This should represent the location on local disk where your models are located. "
+					+ "If you are running this via maven, please run with a -Dmodel.home=/path/to/model/dir. "
+					+ "Make sure that the directory that you pass exists.");
 		}
 		if(modelName == null) {
 			throw new RuntimeException("The system property \"" + MODEL_NAME_PROPERTY + "\" is not set.  If you are running this from an IDE, please set it.  If you are running this from Maven, this should be set automatically and there is something strange going on." );

--- a/src/test/java/de/kherud/llama/LlamaModelIT.java
+++ b/src/test/java/de/kherud/llama/LlamaModelIT.java
@@ -20,8 +20,8 @@ public class LlamaModelIT {
 	public static void setup() {
 		LlamaModel.setLogger((level, msg) -> logOutput += msg);
 		ModelParameters params = new ModelParameters()
-										.setNGpuLayers(43)
-										.setEmbedding(true);
+				.setNGpuLayers(43)
+				.setEmbedding(true);
 		model =
 				new LlamaModel(ModelResolver.getPathToITModel(), params);
 	}

--- a/src/test/java/de/kherud/llama/LlamaModelIT.java
+++ b/src/test/java/de/kherud/llama/LlamaModelIT.java
@@ -19,7 +19,9 @@ public class LlamaModelIT {
 	@BeforeClass
 	public static void setup() {
 		LlamaModel.setLogger((level, msg) -> logOutput += msg);
-		ModelParameters params = new ModelParameters().setNGpuLayers(43).setEmbedding(true);
+		ModelParameters params = new ModelParameters()
+										.setNGpuLayers(43)
+										.setEmbedding(true);
 		model =
 				new LlamaModel(ModelResolver.getPathToITModel(), params);
 	}

--- a/src/test/java/de/kherud/llama/LlamaModelIT.java
+++ b/src/test/java/de/kherud/llama/LlamaModelIT.java
@@ -1,6 +1,5 @@
 package de.kherud.llama;
 
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/test/java/de/kherud/llama/ModelResolver.java
+++ b/src/test/java/de/kherud/llama/ModelResolver.java
@@ -1,0 +1,32 @@
+package de.kherud.llama;
+
+import java.nio.file.Paths;
+
+public enum ModelResolver {
+  MODEL_HOME("model.home", "Please pass the system property \"%s\" to the test. "
+      + "This should represent the location on local disk where your models are located. "
+      + "If you are running this via maven, please run with a -Dmodel.home=/path/to/model/dir. "
+      + "Make sure that the directory that you pass exists." ),
+  INTEGRATION_TEST_MODEL_NAME("integration.test.model", "The system property \"%s\" is not set.  If you are running this from an IDE, please set it.  If you are running this from Maven, this should be set automatically and there is something strange going on." );
+  final String systemPropertyName;
+  final String errorMessage;
+  ModelResolver(String systemPropertyName, String errorMessage) {
+    this.systemPropertyName = systemPropertyName;
+    this.errorMessage = errorMessage;
+  }
+
+  public String resolve() {
+    String ret = System.getProperty(systemPropertyName);
+    if(ret == null) {
+      throw new IllegalArgumentException(String.format(errorMessage, systemPropertyName));
+    }
+    return ret;
+  }
+
+  public static String getPathToModel(String modelName) {
+    return Paths.get(MODEL_HOME.resolve(), modelName).toString();
+  }
+  public static String getPathToITModel() {
+    return getPathToModel(INTEGRATION_TEST_MODEL_NAME.resolve());
+  }
+}

--- a/src/test/java/de/kherud/llama/ModelResolver.java
+++ b/src/test/java/de/kherud/llama/ModelResolver.java
@@ -2,6 +2,10 @@ package de.kherud.llama;
 
 import java.nio.file.Paths;
 
+
+/**
+ * An enum which enables us to resolve the model home from system parameters and full model paths.
+ */
 public enum ModelResolver {
   MODEL_HOME("model.home", "Please pass the system property \"%s\" to the test. "
       + "This should represent the location on local disk where your models are located. "

--- a/src/test/java/examples/GrammarExample.java
+++ b/src/test/java/examples/GrammarExample.java
@@ -1,5 +1,6 @@
 package examples;
 
+import de.kherud.llama.ModelResolver;
 import java.util.HashMap;
 
 import de.kherud.llama.InferenceParameters;
@@ -12,9 +13,9 @@ public class GrammarExample {
 				"expr  ::= term ([-+*/] term)*\n" +
 				"term  ::= [0-9]";
 		InferenceParameters params = new InferenceParameters().setGrammar(grammar);
-
-		String filePath = "/run/media/konstantin/Seagate/models/llama2/llama-2-13b-chat/gguf-model-q4_0.bin";
-		try (LlamaModel model = new LlamaModel(filePath)) {
+		String modelName = System.getProperty("model.name");
+		String modelPath = modelName == null?ModelResolver.getPathToITModel():ModelResolver.getPathToModel(modelName);
+		try (LlamaModel model = new LlamaModel(modelPath)) {
 			for (LlamaModel.Output output : model.generate("", params)) {
 				System.out.print(output);
 			}

--- a/src/test/java/examples/GrammarExample.java
+++ b/src/test/java/examples/GrammarExample.java
@@ -14,7 +14,7 @@ public class GrammarExample {
 				"term  ::= [0-9]";
 		InferenceParameters params = new InferenceParameters().setGrammar(grammar);
 		String modelName = System.getProperty("model.name");
-		String modelPath = modelName == null?ModelResolver.getPathToITModel():ModelResolver.getPathToModel(modelName);
+		String modelPath = ModelResolver.getPathToModel(modelName);
 		try (LlamaModel model = new LlamaModel(modelPath)) {
 			for (LlamaModel.Output output : model.generate("", params)) {
 				System.out.print(output);

--- a/src/test/java/examples/InfillExample.java
+++ b/src/test/java/examples/InfillExample.java
@@ -2,6 +2,7 @@ package examples;
 
 import de.kherud.llama.LlamaModel;
 import de.kherud.llama.ModelParameters;
+import de.kherud.llama.ModelResolver;
 
 public class InfillExample {
 
@@ -12,8 +13,8 @@ public class InfillExample {
 
 		String prefix = "def remove_non_ascii(s: str) -> str:\n    \"\"\" ";
 		String suffix = "\n    return result\n";
-
-		String modelPath = "/run/media/konstantin/Seagate/models/codellama-13b.q5_k_m.gguf";
+		String modelName = System.getProperty("model.name");
+		String modelPath = modelName == null? ModelResolver.getPathToITModel():ModelResolver.getPathToModel(modelName);
 		try (LlamaModel model = new LlamaModel(modelPath, modelParams)) {
 			System.out.print(prefix);
 			for (LlamaModel.Output output : model.generate(prefix, suffix)) {

--- a/src/test/java/examples/InfillExample.java
+++ b/src/test/java/examples/InfillExample.java
@@ -14,7 +14,7 @@ public class InfillExample {
 		String prefix = "def remove_non_ascii(s: str) -> str:\n    \"\"\" ";
 		String suffix = "\n    return result\n";
 		String modelName = System.getProperty("model.name");
-		String modelPath = modelName == null? ModelResolver.getPathToITModel():ModelResolver.getPathToModel(modelName);
+		String modelPath = ModelResolver.getPathToModel(modelName);
 		try (LlamaModel model = new LlamaModel(modelPath, modelParams)) {
 			System.out.print(prefix);
 			for (LlamaModel.Output output : model.generate(prefix, suffix)) {

--- a/src/test/java/examples/MainExample.java
+++ b/src/test/java/examples/MainExample.java
@@ -17,7 +17,7 @@ public class MainExample {
         ModelParameters modelParams = new ModelParameters()
                 .setNGpuLayers(43);
         InferenceParameters inferParams = new InferenceParameters()
-                .setTemperature(0f)
+                .setTemperature(0.7f)
                 .setPenalizeNl(true)
 //                .setNProbs(10)
                 .setMirostat(InferenceParameters.MiroStat.V2)

--- a/src/test/java/examples/MainExample.java
+++ b/src/test/java/examples/MainExample.java
@@ -17,16 +17,19 @@ public class MainExample {
         ModelParameters modelParams = new ModelParameters()
                 .setNGpuLayers(43);
         InferenceParameters inferParams = new InferenceParameters()
-                .setTemperature(0.7f)
+                .setTemperature(0f)
                 .setPenalizeNl(true)
 //                .setNProbs(10)
                 .setMirostat(InferenceParameters.MiroStat.V2)
-                .setAntiPrompt("\n");
+                .setAntiPrompt("User:");
         String modelName = System.getProperty("model.name");
-        String modelPath = modelName == null? ModelResolver.getPathToITModel():ModelResolver.getPathToModel(modelName);
+        String modelPath = ModelResolver.getPathToModel(modelName);
         String system = "This is a conversation between User and Llama, a friendly chatbot.\n" +
                 "Llama is helpful, kind, honest, good at writing, and never fails to answer any " +
-                "requests immediately and with precision.\n";
+                "requests immediately and with precision.\n\n" +
+                "User: Hello Llama\n" +
+                "Llama: Hello.  How may I help you today?";
+                ;
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
         try (LlamaModel model = new LlamaModel(modelPath, modelParams)) {
             System.out.print(system);

--- a/src/test/java/examples/MainExample.java
+++ b/src/test/java/examples/MainExample.java
@@ -1,5 +1,6 @@
 package examples;
 
+import de.kherud.llama.ModelResolver;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -21,8 +22,8 @@ public class MainExample {
 //                .setNProbs(10)
                 .setMirostat(InferenceParameters.MiroStat.V2)
                 .setAntiPrompt("\n");
-
-        String modelPath = "/run/media/konstantin/Seagate/models/llama2/llama-2-13b-chat/ggml-model-q4_0.gguf";
+        String modelName = System.getProperty("model.name");
+        String modelPath = modelName == null? ModelResolver.getPathToITModel():ModelResolver.getPathToModel(modelName);
         String system = "This is a conversation between User and Llama, a friendly chatbot.\n" +
                 "Llama is helpful, kind, honest, good at writing, and never fails to answer any " +
                 "requests immediately and with precision.\n";


### PR DESCRIPTION
This PR does the following:
* Upgrades llama.cpp to the most recent release of llama.cpp: [b1645](https://github.com/ggerganov/llama.cpp/releases/tag/b1645).  **This enables the library to load mixtral models**
* Slightly adjusts the testing
  * Moves the only test to operate as an integration test in maven
  * Removes the hard coded model expectation and downloads the model if it doesn't exist when run via maven

After this PR, you can run the integration tests via maven like so:
`mvn verify -Dmodel.home=$HOME/llm/models`
Note:
1. `$HOME/llm/models` is the model home directory.  This is where the integration test model will be stored.  
2. The assumption is only that the directory exist (otherwise it errors out appropriately).  If the model (a version of mistral 7b) doesn't exist in the directory it will download it

# Examples
In addition to refactoring the unit test, I reran the examples.  I modified the examples to be able to be run via maven:
```
# Run the MainExample with the codellama model.  Note: the model must exist.
mvn exec:java -Dexec.mainClass="examples.MainExample" -Dmodel.home="/Users/cstella/llm/models" -Dmodel.name="codellama-13b.Q5_K_M.gguf"
```
## `examples.GrammarExample`
```
mvn exec:java -Dexec.mainClass="examples.GrammarExample" -Dmodel.home="/Users/cstella/llm/models" -Dmodel.name="codellama-13b.Q5_K_M.gguf"
...
root ::= root_4
root_1 ::= expr [=] term [<U+000A>]
expr ::= term expr_6
term ::= [0-9]
root_4 ::= root_1 root_4 | root_1
expr_5 ::= [-+*/] term
expr_6 ::= expr_5 expr_6 |
4-3-1-2-3-4-1-1-1-1-1-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-...
```
This looks roughly like what I see if I run the same example from main:
```
4-3-1-2-3-4-3-3-4-5-6-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-1-2-3-4-5-6-7-8-9-0-1-2-3 ...
```

## `examples.InfillExample`
With the new code I see:
```
def remove_non_ascii(s: str) -> str:
    """ Removes non-ASCII characters from a string """
    # Remove all non-ascii characters.
    result = b''.join(
        c for c in s if 0x20 <= ord(c) < 0x7F).decode() <EOT>
    return result
```
With master I see:
```
def remove_non_ascii(s: str) -> str:
    """ remove non-ASCII characters from a string """
    try:
        result = s.encode("latin1", "replace").decode()
    except AttributeError:
        result = str(s).encode("latin1", "replace").decode() <EOT>
    return result
```

## `examples.MainExample`
I made a couple of modifications to both the old version and the new version to compare:
* I changed the AntiPrompt to `User:` so it actually completes the statement
* I have the system prompt expanded to include a greeting

With this PR I see:
```
User: Hello Llama
Llama: Hello.  How may I help you today?
User: Hi can you write a python function that computes the nth fibonacci number?
Llama:
def fib(n):
    if n == 0:
        return 0
    elif n == 1:
        return 1
    else:
        return fib(n-1) + fib(n-2)

User:
```

With master I see:
```
This is a conversation between User and Llama, a friendly chatbot.
Llama is helpful, kind, honest, good at writing, and never fails to answer any requests immediately and with precision.

User: Hello Llama
Llama: Hello.  How may I help you today?
User: Hi can you write a function that computes the nth fibonnaci number in python?
Llama:  Sure, here is my code:
def fib(n):
    if n == 0 or n == 1:
        return n
    else:
        return fib(n-1) + fib(n-2)

```