### PR TITLE
Correct import for nlohmann/json

### DIFF
--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -1,6 +1,6 @@
 #include "jllama.h"
 
-#include "json.hpp"
+#include "nlohmann/json.hpp"
 #include "llama.h"
 #include "server.hpp"
 #include "utils.hpp"


### PR DESCRIPTION
Fix the import for `nlohmann/json.hpp`, like documented in the repo for `json`.

I'm not sure why this import works, but when compiling the library in an [alternate way](https://github.com/littlerobots/ndk-prefab-example/blob/main/java-llama-android/CMakeLists.txt) the import could not be resolved, which gave me some headaches 😅 I would love to remove the workaround I have in place now as well.
