### PR TITLE
Update to b2885

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             cmake: '-DLLAMA_METAL=OFF'
           }
           - {
-            runner: macos-latest,
+            runner: macos-14,
             cmake: '-DLLAMA_METAL_EMBED_LIBRARY=ON -DLLAMA_METAL=OFF'
           }
     steps:
@@ -51,7 +51,6 @@ jobs:
           java-version: '11'
       - name: Build libraries
         run: |
-          uname -a
           mvn compile
           .github/build.sh ${{ matrix.target.cmake }}
       - name: Download model

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           java-version: '11'
       - name: Build libraries
         run: |
+          uname -a
           mvn compile
           .github/build.sh ${{ matrix.target.cmake }}
       - name: Download model

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
       matrix:
         target:
           - {
-            runner: macos-latest,
+            runner: macos-13,
             cmake: '-DLLAMA_METAL=OFF'
           }
           - {
-            runner: macos-14,
+            runner: macos-latest,
             cmake: '-DLLAMA_METAL_EMBED_LIBRARY=ON -DLLAMA_METAL=OFF'
           }
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,24 +28,35 @@ jobs:
       - name: Run tests
         run: mvn test
 
-# disabled for now, we don't have access to a macos arm64 runner and testing on x86_64 doesn't work
-#  build-and-test-macos:
-#    name: macos-latest
-#    runs-on: macos-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-java@v4
-#        with:
-#          distribution: 'zulu'
-#          java-version: '11'
-#      - name: Download model
-#        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
-#      - name: Build libraries
-#        run: |
-#          mvn compile
-#          .github/build.sh -DLLAMA_METAL_EMBED_LIBRARY=ON
-#      - name: Run tests
-#        run: mvn test
+  build-and-test-macos:
+    name: ${{ matrix.target.runner }}
+    runs-on: ${{ matrix.target.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - {
+            runner: macos-latest,
+            cmake: '-DLLAMA_METAL=OFF'
+          }
+          - {
+            runner: macos-14,
+            cmake: '-DLLAMA_METAL_EMBED_LIBRARY=ON'
+          }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Download model
+        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
+      - name: Build libraries
+        run: |
+          mvn compile
+          .github/build.sh ${{ matrix.target.cmake }}
+      - name: Run tests
+        run: mvn test
 
   build-and-test-windows:
     name: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-      - name: Download model
-        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
       - name: Build libraries
         # cmake should figure out OS and ARCH automatically when running build.sh (but we need mvn compile for it)
         run: |
           mvn compile
           .github/build.sh
+      - name: Download model
+        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
       - name: Run tests
         run: mvn test
 
@@ -49,12 +49,12 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-      - name: Download model
-        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
       - name: Build libraries
         run: |
           mvn compile
           .github/build.sh ${{ matrix.target.cmake }}
+      - name: Download model
+        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
       - name: Run tests
         run: mvn test
 
@@ -67,11 +67,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-      - name: Download model
-        run: curl -L $env:MODEL_URL --create-dirs -o models/$env:MODEL_NAME
       - name: Build libraries
         run: |
           mvn compile
           .github\build.bat
+      - name: Download model
+        run: curl -L $env:MODEL_URL --create-dirs -o models/$env:MODEL_NAME
       - name: Run tests
         run: mvn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           }
           - {
             runner: macos-14,
-            cmake: '-DLLAMA_METAL_EMBED_LIBRARY=ON'
+            cmake: '-DLLAMA_METAL_EMBED_LIBRARY=ON -DLLAMA_METAL=OFF'
           }
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,21 +50,17 @@ jobs:
 
 
   build-macos-native:
-    name: Build ${{ matrix.target.os }}-${{ matrix.target.arch }}
+    name: Build ${{ matrix.target.runner }}
     runs-on: ${{ matrix.target.runner }}
     strategy:
       fail-fast: false
       matrix:
         target:
           - {
-            os: Mac,
-            arch: x86_64,
-            runner: macos-latest,
+            runner: macos-13,
             cmake: '-DLLAMA_METAL=OFF'
           }
           - {
-            os: Mac,
-            arch: aarch64,
             runner: macos-14,
             cmake: '-DLLAMA_METAL_EMBED_LIBRARY=ON'
           }
@@ -73,7 +69,7 @@ jobs:
       - name: Build libraries
         shell: bash
         run: |
-          .github/build.sh ${{ matrix.target.cmake }} -DOS_NAME=${{ matrix.target.os }} -DOS_ARCH=${{ matrix.target.arch }}
+          .github/build.sh ${{ matrix.target.cmake }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ FetchContent_MakeAvailable(json)
 FetchContent_Declare(
 	llama.cpp
 	GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-	GIT_TAG        b2797
+	GIT_TAG        b2885
 )
 FetchContent_MakeAvailable(llama.cpp)
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This is a short example on how to use this library:
 ```java
 public class Example {
 
-	public static void main(String... args) throws IOException {
+    public static void main(String... args) throws IOException {
         ModelParameters modelParams = new ModelParameters()
                 .setModelFilePath("/path/to/model.gguf")
                 .setNGpuLayers(43);
@@ -152,12 +152,12 @@ public class Example {
                 prompt += input;
                 System.out.print("Llama: ");
                 prompt += "\nLlama: ";
-				InferenceParameters inferParams = new InferenceParameters(prompt)
-						.setTemperature(0.7f)
-						.setPenalizeNl(true)
-						.setMirostat(InferenceParameters.MiroStat.V2)
-						.setAntiPrompt("\n");
-                for (String output : model.generate(inferParams)) {
+                InferenceParameters inferParams = new InferenceParameters(prompt)
+                        .setTemperature(0.7f)
+                        .setPenalizeNl(true)
+                        .setMirostat(InferenceParameters.MiroStat.V2)
+                        .setAntiPrompt("\n");
+                for (LlamaOutput output : model.generate(inferParams)) {
                     System.out.print(output);
                     prompt += output;
                 }
@@ -180,7 +180,7 @@ ModelParameters modelParams = new ModelParameters().setModelFilePath("/path/to/m
 InferenceParameters inferParams = new InferenceParameters("Tell me a joke.");
 try (LlamaModel model = new LlamaModel(modelParams)) {
     // Stream a response and access more information about each output.
-    for (String output : model.generate(inferParams)) {
+    for (LlamaOutput output : model.generate(inferParams)) {
         System.out.print(output);
     }
     // Calculate a whole response before returning it.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.kherud</groupId>
 	<artifactId>llama</artifactId>
-	<version>3.0.2</version>
+	<version>3.1.0</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -110,9 +110,9 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
     // find classes
     c_llama_model = env->FindClass("de/kherud/llama/LlamaModel");
-    c_llama_iterator = env->FindClass("de/kherud/llama/LlamaModel$LlamaIterator");
+    c_llama_iterator = env->FindClass("de/kherud/llama/LlamaIterator");
     c_standard_charsets = env->FindClass("java/nio/charset/StandardCharsets");
-    c_output = env->FindClass("de/kherud/llama/LlamaModel$Output");
+    c_output = env->FindClass("de/kherud/llama/LlamaOutput");
     c_string = env->FindClass("java/lang/String");
     c_hash_map = env->FindClass("java/util/HashMap");
     c_map = env->FindClass("java/util/Map");
@@ -497,4 +497,12 @@ JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_delete(JNIEnv *env, jobje
     // maybe we should keep track how many models were loaded before freeing the backend
     llama_backend_free();
     delete ctx_server;
+}
+
+JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_cancelCompletion(JNIEnv *env, jobject obj, jint id_task)
+{
+    jlong server_handle = env->GetLongField(obj, f_model_pointer);
+    auto *ctx_server = reinterpret_cast<server_context *>(server_handle); // NOLINT(*-no-int-to-ptr)
+    ctx_server->request_cancel(id_task);
+    ctx_server->queue_results.remove_waiting_task_id(id_task);
 }

--- a/src/main/cpp/jllama.h
+++ b/src/main/cpp/jllama.h
@@ -25,14 +25,6 @@ JNIEXPORT jintArray JNICALL Java_de_kherud_llama_LlamaModel_encode
 
 /*
  * Class:     de_kherud_llama_LlamaModel
- * Method:    loadModel
- * Signature: (Ljava/lang/String;)V
- */
-JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_loadModel
-  (JNIEnv *, jobject, jstring);
-
-/*
- * Class:     de_kherud_llama_LlamaModel
  * Method:    requestCompletion
  * Signature: (Ljava/lang/String;)I
  */
@@ -41,10 +33,18 @@ JNIEXPORT jint JNICALL Java_de_kherud_llama_LlamaModel_requestCompletion
 
 /*
  * Class:     de_kherud_llama_LlamaModel
- * Method:    receiveGeneration
- * Signature: (I)Lde/kherud/llama/LlamaModel/Output;
+ * Method:    receiveCompletion
+ * Signature: (I)Lde/kherud/llama/LlamaOutput;
  */
 JNIEXPORT jobject JNICALL Java_de_kherud_llama_LlamaModel_receiveCompletion
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     de_kherud_llama_LlamaModel
+ * Method:    cancelCompletion
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_cancelCompletion
   (JNIEnv *, jobject, jint);
 
 /*
@@ -54,6 +54,14 @@ JNIEXPORT jobject JNICALL Java_de_kherud_llama_LlamaModel_receiveCompletion
  */
 JNIEXPORT jbyteArray JNICALL Java_de_kherud_llama_LlamaModel_decodeBytes
   (JNIEnv *, jobject, jintArray);
+
+/*
+ * Class:     de_kherud_llama_LlamaModel
+ * Method:    loadModel
+ * Signature: (Ljava/lang/String;)V
+ */
+JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_loadModel
+  (JNIEnv *, jobject, jstring);
 
 /*
  * Class:     de_kherud_llama_LlamaModel

--- a/src/main/cpp/utils.hpp
+++ b/src/main/cpp/utils.hpp
@@ -43,7 +43,7 @@ extern bool server_log_json;
 #define LOG_INFO(MSG, ...) server_log("INFO", __func__, __LINE__, MSG, __VA_ARGS__)
 
 static inline void server_log(const char *level, const char *function, int line, const char *message,
-                              const nlohmann::ordered_json &extra);
+                              const json &extra);
 
 template <typename T> static T json_value(const json &body, const std::string &key, const T &default_value)
 {
@@ -52,13 +52,14 @@ template <typename T> static T json_value(const json &body, const std::string &k
     {
         try
         {
-            return body.value(key, default_value);
+            return body.at(key);
         }
-        catch (nlohmann::json_abi_v3_11_3::detail::type_error const &)
+        catch (NLOHMANN_JSON_NAMESPACE::detail::type_error const &)
         {
-            std::string message = "Wrong type supplied for parameter '" + key + "'. Expected '" +
-                                  typeid(default_value).name() + "', using default value.";
-            server_log("WARN", __func__, __LINE__, message.c_str(), body);
+            std::stringstream ss;
+            ss << "Wrong type supplied for parameter '" << key << "'. Expected '" << json(default_value).type_name()
+               << "', using default value.";
+            LOG_WARNING(ss.str().c_str(), body);
             return default_value;
         }
     }
@@ -68,12 +69,11 @@ template <typename T> static T json_value(const json &body, const std::string &k
     }
 }
 
-static inline void server_log(const char *level, const char *function, int line, const char *message,
-                              const nlohmann::ordered_json &extra)
+static inline void server_log(const char *level, const char *function, int line, const char *message, const json &extra)
 {
     std::stringstream ss_tid;
     ss_tid << std::this_thread::get_id();
-    json log = nlohmann::ordered_json{
+    json log = json{
         {"tid", ss_tid.str()},
         {"timestamp", time(nullptr)},
     };
@@ -411,25 +411,21 @@ static json oaicompat_completion_params_parse(const struct llama_model *model,
     llama_params["presence_penalty"] = json_value(body, "presence_penalty", 0.0);
     llama_params["seed"] = json_value(body, "seed", LLAMA_DEFAULT_SEED);
     llama_params["stream"] = json_value(body, "stream", false);
-    llama_params["temperature"] = json_value(body, "temperature", 0.0);
+    llama_params["temperature"] = json_value(body, "temperature", 1.0);
     llama_params["top_p"] = json_value(body, "top_p", 1.0);
 
     // Apply chat template to the list of messages
-    llama_params["prompt"] = format_chat(model, chat_template, body["messages"]);
+    llama_params["prompt"] = format_chat(model, chat_template, body.at("messages"));
 
     // Handle "stop" field
-    if (body.contains("stop") && body["stop"].is_string())
+    if (body.contains("stop") && body.at("stop").is_string())
     {
-        llama_params["stop"] = json::array({body["stop"].get<std::string>()});
+        llama_params["stop"] = json::array({body.at("stop").get<std::string>()});
     }
     else
     {
         llama_params["stop"] = json_value(body, "stop", json::array());
     }
-    // Some chat templates don't use EOS token to stop generation
-    // We must add their end sequences to list of stop words
-    llama_params["stop"].push_back("<|im_end|>");    // chatml
-    llama_params["stop"].push_back("<end_of_turn>"); // gemma
 
     // Handle "response_format" field
     if (body.contains("response_format"))
@@ -626,6 +622,14 @@ static std::vector<json> format_partial_response_oaicompat(json result, const st
                     {"id", completion_id},
                     {"model", modelname},
                     {"object", "chat.completion.chunk"}};
+    if (!finish_reason.empty())
+    {
+        int num_tokens_predicted = json_value(result, "tokens_predicted", 0);
+        int num_prompt_tokens = json_value(result, "tokens_evaluated", 0);
+        ret.push_back({"usage", json{{"completion_tokens", num_tokens_predicted},
+                                     {"prompt_tokens", num_prompt_tokens},
+                                     {"total_tokens", num_tokens_predicted + num_prompt_tokens}}});
+    }
 
     return std::vector<json>({ret});
 }

--- a/src/main/java/de/kherud/llama/LlamaIterable.java
+++ b/src/main/java/de/kherud/llama/LlamaIterable.java
@@ -1,0 +1,15 @@
+package de.kherud.llama;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An iterable used by {@link LlamaModel#generate(InferenceParameters)} that specifically returns a {@link LlamaIterator}.
+ */
+@FunctionalInterface
+public interface LlamaIterable extends Iterable<LlamaOutput> {
+
+    @NotNull
+    @Override
+    LlamaIterator iterator();
+
+}

--- a/src/main/java/de/kherud/llama/LlamaIterator.java
+++ b/src/main/java/de/kherud/llama/LlamaIterator.java
@@ -1,0 +1,48 @@
+package de.kherud.llama;
+
+import java.lang.annotation.Native;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * This iterator is used by {@link LlamaModel#generate(InferenceParameters)}. In addition to implementing {@link Iterator},
+ * it allows to cancel ongoing inference (see {@link #cancel()}).
+ */
+public final class LlamaIterator implements Iterator<LlamaOutput> {
+
+    private final LlamaModel model;
+    private final int taskId;
+
+    @Native
+    @SuppressWarnings("FieldMayBeFinal")
+    private boolean hasNext = true;
+
+    LlamaIterator(LlamaModel model, InferenceParameters parameters) {
+        this.model = model;
+        parameters.setStream(true);
+        taskId = model.requestCompletion(parameters.toString());
+    }
+
+    @Override
+    public boolean hasNext() {
+        return hasNext;
+    }
+
+    @Override
+    public LlamaOutput next() {
+        if (!hasNext) {
+            throw new NoSuchElementException();
+        }
+        LlamaOutput output = model.receiveCompletion(taskId);
+        hasNext = !output.stop;
+        return output;
+    }
+
+    /**
+     * Cancel the ongoing generation process.
+     */
+    public void cancel() {
+        model.cancelCompletion(taskId);
+        hasNext = false;
+    }
+}

--- a/src/main/java/de/kherud/llama/LlamaOutput.java
+++ b/src/main/java/de/kherud/llama/LlamaOutput.java
@@ -1,0 +1,39 @@
+package de.kherud.llama;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * An output of the LLM providing access to the generated text and the associated probabilities. You have to configure
+ * {@link InferenceParameters#setNProbs(int)} in order for probabilities to be returned.
+ */
+public final class LlamaOutput {
+
+    /**
+     * The last bit of generated text that is representable as text (i.e., cannot be individual utf-8 multibyte code
+     * points).
+     */
+    @NotNull
+    public final String text;
+
+    /**
+     * Note, that you have to configure {@link InferenceParameters#setNProbs(int)} in order for probabilities to be returned.
+     */
+    @NotNull
+    public final Map<String, Float> probabilities;
+
+    final boolean stop;
+
+    LlamaOutput(byte[] generated, @NotNull Map<String, Float> probabilities, boolean stop) {
+        this.text = new String(generated, StandardCharsets.UTF_8);
+        this.probabilities = probabilities;
+        this.stop = stop;
+    }
+
+    @Override
+    public String toString() {
+        return text;
+    }
+}

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -132,6 +132,22 @@ public class LlamaModelTest {
 	}
 
 	@Test
+	public void testCancelGenerating() {
+		InferenceParameters params = new InferenceParameters(prefix).setNPredict(nPredict);
+
+		int generated = 0;
+		LlamaIterator iterator = model.generate(params).iterator();
+		while (iterator.hasNext()) {
+			iterator.next();
+			generated++;
+			if (generated == 5) {
+				iterator.cancel();
+			}
+		}
+		Assert.assertEquals(5, generated);
+	}
+
+	@Test
 	public void testEmbedding() {
 		float[] embedding = model.embed(prefix);
 		Assert.assertEquals(4096, embedding.length);

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -45,7 +45,7 @@ public class LlamaModelTest {
 				.setTokenIdBias(logitBias);
 
 		int generated = 0;
-		for (LlamaModel.Output ignored : model.generate(params)) {
+		for (LlamaOutput ignored : model.generate(params)) {
 			generated++;
 		}
 		// todo: currently, after generating nPredict tokens, there is an additional empty output
@@ -66,7 +66,7 @@ public class LlamaModelTest {
 				.setSeed(42);
 
 		int generated = 0;
-		for (LlamaModel.Output ignored : model.generate(params)) {
+		for (LlamaOutput ignored : model.generate(params)) {
 			generated++;
 		}
 		Assert.assertTrue(generated > 0 && generated <= nPredict + 1);
@@ -78,7 +78,7 @@ public class LlamaModelTest {
 				.setGrammar("root ::= (\"a\" | \"b\")+")
 				.setNPredict(nPredict);
 		StringBuilder sb = new StringBuilder();
-		for (LlamaModel.Output output : model.generate(params)) {
+		for (LlamaOutput output : model.generate(params)) {
 			sb.append(output);
 		}
 		String output = sb.toString();

--- a/src/test/java/examples/GrammarExample.java
+++ b/src/test/java/examples/GrammarExample.java
@@ -1,5 +1,6 @@
 package examples;
 
+import de.kherud.llama.LlamaOutput;
 import de.kherud.llama.ModelParameters;
 
 import de.kherud.llama.InferenceParameters;
@@ -16,7 +17,7 @@ public class GrammarExample {
 		InferenceParameters inferParams = new InferenceParameters("")
 				.setGrammar(grammar);
 		try (LlamaModel model = new LlamaModel(modelParams)) {
-			for (LlamaModel.Output output : model.generate(inferParams)) {
+			for (LlamaOutput output : model.generate(inferParams)) {
 				System.out.print(output);
 			}
 		}

--- a/src/test/java/examples/InfillExample.java
+++ b/src/test/java/examples/InfillExample.java
@@ -2,6 +2,7 @@ package examples;
 
 import de.kherud.llama.InferenceParameters;
 import de.kherud.llama.LlamaModel;
+import de.kherud.llama.LlamaOutput;
 import de.kherud.llama.ModelParameters;
 
 public class InfillExample {
@@ -18,7 +19,7 @@ public class InfillExample {
 			InferenceParameters inferParams = new InferenceParameters("")
 					.setInputPrefix(prefix)
 					.setInputSuffix(suffix);
-			for (LlamaModel.Output output : model.generate(inferParams)) {
+			for (LlamaOutput output : model.generate(inferParams)) {
 				System.out.print(output);
 			}
 			System.out.print(suffix);

--- a/src/test/java/examples/MainExample.java
+++ b/src/test/java/examples/MainExample.java
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 
 import de.kherud.llama.InferenceParameters;
 import de.kherud.llama.LlamaModel;
+import de.kherud.llama.LlamaOutput;
 import de.kherud.llama.ModelParameters;
 import de.kherud.llama.args.MiroStat;
 
@@ -39,7 +40,7 @@ public class MainExample {
 						.setPenalizeNl(true)
 						.setMiroStat(MiroStat.V2)
 						.setStopStrings("User:");
-                for (LlamaModel.Output output : model.generate(inferParams)) {
+                for (LlamaOutput output : model.generate(inferParams)) {
                     System.out.print(output);
                     prompt += output;
                 }


### PR DESCRIPTION
# Version 3.1.0

- Updates to llama.cpp b2885
- Fixes #62 (generation can now be canceled)
- Fixes macos x64 shared libraries

API changes:

- `LlamaModel.Output` is now `LlamaOutput`
- `LlamaIterator` is now public, was private `LlamaModel.Iterator` previously