### PR TITLE
Update workflow upload/download artifacts to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
       - name: Run tests
         run: mvn test
       - if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: error-log-linux
           path: ${{ github.workspace }}/hs_err_pid*.log
           if-no-files-found: warn
 
@@ -62,6 +63,12 @@ jobs:
         run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
       - name: Run tests
         run: mvn test
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: error-log-macos
+          path: ${{ github.workspace }}/hs_err_pid*.log
+          if-no-files-found: warn
 
   build-and-test-windows:
     name: windows-latest
@@ -81,7 +88,8 @@ jobs:
       - name: Run tests
         run: mvn test
       - if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: error-log-windows
           path: ${{ github.workspace }}\hs_err_pid*.log
           if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
         run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
       - name: Run tests
         run: mvn test
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-libraries
+          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
       - if: failure()
         uses: actions/upload-artifact@v3
         with:
@@ -62,6 +67,11 @@ jobs:
         run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
       - name: Run tests
         run: mvn test
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-libraries
+          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
 
   build-and-test-windows:
     name: windows-latest
@@ -80,8 +90,75 @@ jobs:
         run: curl -L $env:MODEL_URL --create-dirs -o models/$env:MODEL_NAME
       - name: Run tests
         run: mvn test
-      - if: failure()
-        uses: actions/upload-artifact@v3
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
         with:
+          name: windows-libraries
+          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: error-log-windows
           path: ${{ github.workspace }}\hs_err_pid*.log
           if-no-files-found: warn
+
+  test-linux:
+    name: Test Linux
+    needs: build-and-test-linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*-libraries"
+          merge-multiple: true
+          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
+      - name: Download model
+        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Run tests
+        run: mvn test
+
+  test-macos:
+    name: Test Mac
+    needs: build-and-test-macos
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*-libraries"
+          merge-multiple: true
+          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
+      - name: Download model
+        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Run tests
+        run: mvn test
+
+
+  test-windows:
+    name: Test Windows
+    needs: build-and-test-windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*-libraries"
+          merge-multiple: true
+          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
+      - name: Download model
+        run: curl -L $env:MODEL_URL --create-dirs -o models/$env:MODEL_NAME
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Run tests
+        run: mvn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,6 @@ jobs:
         run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
       - name: Run tests
         run: mvn test
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-libraries
-          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
       - if: failure()
         uses: actions/upload-artifact@v3
         with:
@@ -67,11 +62,6 @@ jobs:
         run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
       - name: Run tests
         run: mvn test
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-libraries
-          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
 
   build-and-test-windows:
     name: windows-latest
@@ -90,75 +80,8 @@ jobs:
         run: curl -L $env:MODEL_URL --create-dirs -o models/$env:MODEL_NAME
       - name: Run tests
         run: mvn test
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-libraries
-          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
       - if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
-          name: error-log-windows
           path: ${{ github.workspace }}\hs_err_pid*.log
           if-no-files-found: warn
-
-  test-linux:
-    name: Test Linux
-    needs: build-and-test-linux
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: "*-libraries"
-          merge-multiple: true
-          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
-      - name: Download model
-        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '11'
-      - name: Run tests
-        run: mvn test
-
-  test-macos:
-    name: Test Mac
-    needs: build-and-test-macos
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: "*-libraries"
-          merge-multiple: true
-          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
-      - name: Download model
-        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '11'
-      - name: Run tests
-        run: mvn test
-
-
-  test-windows:
-    name: Test Windows
-    needs: build-and-test-windows
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: "*-libraries"
-          merge-multiple: true
-          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
-      - name: Download model
-        run: curl -L $env:MODEL_URL --create-dirs -o models/$env:MODEL_NAME
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '11'
-      - name: Run tests
-        run: mvn test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,9 @@ jobs:
         run: |
           .github/dockcross/dockcross-manylinux_2_28-x64 .github/build_cuda_linux.sh "-DOS_NAME=Linux -DOS_ARCH=x86_64"
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: linux-libraries-cuda
           path: ${{ github.workspace }}/src/main/resources_linux_cuda/de/kherud/llama/
 
   build-linux-docker:
@@ -57,9 +57,9 @@ jobs:
         run: |
           .github/dockcross/${{ matrix.target.image }} .github/build.sh "-DOS_NAME=${{ matrix.target.os }} -DOS_ARCH=${{ matrix.target.arch }}"
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: linux-libraries
           path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
 
 
@@ -86,9 +86,9 @@ jobs:
           mvn compile
           .github/build.sh ${{ matrix.target.cmake }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: macos-libraries
           path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
 
 
@@ -126,9 +126,9 @@ jobs:
         run: |
           .github\build.bat ${{ matrix.target.cmake }} -DOS_NAME=${{ matrix.target.os }} -DOS_ARCH=${{ matrix.target.arch }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: windows-libraries
           path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
 
 
@@ -138,9 +138,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: linux-libraries
           path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
       - name: Download model
         run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
@@ -157,9 +157,9 @@ jobs:
 #    runs-on: macos-14
 #    steps:
 #      - uses: actions/checkout@v4
-#      - uses: actions/download-artifact@v3
+#      - uses: actions/download-artifact@v4
 #        with:
-#          name: artifacts
+#          name: macos-libraries
 #          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
 #      - name: Download model
 #        run: curl -L ${MODEL_URL} --create-dirs -o models/${MODEL_NAME}
@@ -177,9 +177,9 @@ jobs:
 #    runs-on: windows-latest
 #    steps:
 #      - uses: actions/checkout@v4
-#      - uses: actions/download-artifact@v3
+#      - uses: actions/download-artifact@v4
 #        with:
-#          name: artifacts
+#          name: windows-libraries
 #          path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
 #      - name: Download model
 #        run: curl -L $env:MODEL_URL --create-dirs -o models/$env:MODEL_NAME
@@ -197,13 +197,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          pattern: "*-libraries"
+          merge-multiple: true
           path: ${{ github.workspace }}/src/main/resources/de/kherud/llama/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          name: linux-libraries-cuda
           path: ${{ github.workspace }}/src/main/resources_linux_cuda/de/kherud/llama/
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3


### PR DESCRIPTION
This PR updates the GitHub workflows to use `actions/upload-artifact@v4` and `actions/download-artifact@v4` instead of the earlier versions 3 to fix [CVE-2024-42471](https://github.com/advisories/GHSA-cxww-7g56-2vh6).