### PR TITLE
Expose json schema to grammar conversion method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.kherud</groupId>
 	<artifactId>llama</artifactId>
-	<version>3.4.1</version>
+	<version>3.4.2</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/cpp/jllama.cpp
+++ b/src/main/cpp/jllama.cpp
@@ -1,6 +1,7 @@
 #include "jllama.h"
 
 #include "llama.h"
+#include "json-schema-to-grammar.h"
 #include "nlohmann/json.hpp"
 #include "server.hpp"
 
@@ -666,4 +667,12 @@ JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_setLogger(JNIEnv *env, jc
             llama_log_set(log_callback_trampoline, nullptr);
         }
     }
+}
+
+JNIEXPORT jbyteArray JNICALL Java_de_kherud_llama_LlamaModel_jsonSchemaToGrammarBytes(JNIEnv *env, jclass clazz, jstring j_schema)
+{
+    const std::string c_schema = parse_jstring(env, j_schema);
+    nlohmann::ordered_json c_schema_json = nlohmann::ordered_json::parse(c_schema);
+    const std::string c_grammar = json_schema_to_grammar(c_schema_json);
+    return parse_jbytes(env, c_grammar);
 }

--- a/src/main/cpp/jllama.h
+++ b/src/main/cpp/jllama.h
@@ -81,20 +81,19 @@ JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_delete
 
 /*
  * Class:     de_kherud_llama_LlamaModel
+ * Method:    releaseTask
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_releaseTask
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     de_kherud_llama_LlamaModel
  * Method:    jsonSchemaToGrammarBytes
  * Signature: (Ljava/lang/String;)[B
  */
 JNIEXPORT jbyteArray JNICALL Java_de_kherud_llama_LlamaModel_jsonSchemaToGrammarBytes
   (JNIEnv *, jclass, jstring);
-
-
-/*
- * Class:     de_kherud_llama_LlamaModel
- * Method:    releaseTask
- * Signature: ()V
- */
-JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_releaseTask
-  (JNIEnv *, jobject, jint);
 
 #ifdef __cplusplus
 }

--- a/src/main/cpp/jllama.h
+++ b/src/main/cpp/jllama.h
@@ -78,6 +78,14 @@ JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_loadModel
  */
 JNIEXPORT void JNICALL Java_de_kherud_llama_LlamaModel_delete
   (JNIEnv *, jobject);
+  
+/*
+ * Class:     de_kherud_llama_LlamaModel
+ * Method:    jsonSchemaToGrammarBytes
+ * Signature: (Ljava/lang/String;)[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_de_kherud_llama_LlamaModel_jsonSchemaToGrammarBytes
+  (JNIEnv *, jclass, jstring);
 
 #ifdef __cplusplus
 }

--- a/src/main/java/de/kherud/llama/LlamaModel.java
+++ b/src/main/java/de/kherud/llama/LlamaModel.java
@@ -128,4 +128,9 @@ public class LlamaModel implements AutoCloseable {
 
 	private native void delete();
 
+	private static native byte[] jsonSchemaToGrammarBytes(String schema);
+	
+	public static String jsonSchemaToGrammar(String schema) {
+		return new String(jsonSchemaToGrammarBytes(schema), StandardCharsets.UTF_8);
+	}
 }

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -290,7 +290,7 @@ public class LlamaModelTest {
                 "c-kv ::= \"\\\"c\\\"\" space \":\" space string\n" +
                 "char ::= [^\"\\\\\\x7F\\x00-\\x1F] | [\\\\] ([\"\\\\bfnrt] | \"u\" [0-9a-fA-F]{4})\n" +
                 "root ::= \"{\" space  (a-kv a-rest | b-kv b-rest | c-kv )? \"}\" space\n" +
-                "space ::= | \" \" | \"\\n\" [ \\t]{0,20}\n" +
+                "space ::= | \" \" | \"\\n\"{1,2} [ \\t]{0,20}\n" +
                 "string ::= \"\\\"\" char* \"\\\"\" space\n";
 		
 		String actualGrammar = LlamaModel.jsonSchemaToGrammar(schema);

--- a/src/test/java/de/kherud/llama/LlamaModelTest.java
+++ b/src/test/java/de/kherud/llama/LlamaModelTest.java
@@ -269,4 +269,29 @@ public class LlamaModelTest {
 			this.text = text;
 		}
 	}
+	
+	@Test
+	public void testJsonSchemaToGrammar() {
+		String schema = "{\n" +
+                "    \"properties\": {\n" +
+                "        \"a\": {\"type\": \"string\"},\n" +
+                "        \"b\": {\"type\": \"string\"},\n" +
+                "        \"c\": {\"type\": \"string\"}\n" +
+                "    },\n" +
+                "    \"additionalProperties\": false\n" +
+                "}";
+		
+		String expectedGrammar = "a-kv ::= \"\\\"a\\\"\" space \":\" space string\n" +
+                "a-rest ::= ( \",\" space b-kv )? b-rest\n" +
+                "b-kv ::= \"\\\"b\\\"\" space \":\" space string\n" +
+                "b-rest ::= ( \",\" space c-kv )?\n" +
+                "c-kv ::= \"\\\"c\\\"\" space \":\" space string\n" +
+                "char ::= [^\"\\\\\\x7F\\x00-\\x1F] | [\\\\] ([\"\\\\bfnrt] | \"u\" [0-9a-fA-F]{4})\n" +
+                "root ::= \"{\" space  (a-kv a-rest | b-kv b-rest | c-kv )? \"}\" space\n" +
+                "space ::= | \" \" | \"\\n\" [ \\t]{0,20}\n" +
+                "string ::= \"\\\"\" char* \"\\\"\" space\n";
+		
+		String actualGrammar = LlamaModel.jsonSchemaToGrammar(schema);
+		Assert.assertEquals(expectedGrammar, actualGrammar);
+	}
 }


### PR DESCRIPTION
This exposes exposes C++ function to convert JSON schema to GBNF grammar.
GBNF grammar is an inference parameter to generate structured output, which is often useful to reduce hallucinations.
https://github.com/ggml-org/llama.cpp/blob/master/grammars/README.md.






