### PR TITLE
Fix the enums PoolingType and RopeScalingType values and their calls in ModelParameters

### DIFF
--- a/src/main/java/de/kherud/llama/ModelParameters.java
+++ b/src/main/java/de/kherud/llama/ModelParameters.java
@@ -459,7 +459,7 @@ public final class ModelParameters extends CliParameters {
      * Set pooling type for embeddings (default: model default if unspecified).
      */
     public ModelParameters setPoolingType(PoolingType type) {
-        parameters.put("--pooling", String.valueOf(type.getId()));
+        parameters.put("--pooling", type.getArgValue());
         return this;
     }
 
@@ -467,7 +467,7 @@ public final class ModelParameters extends CliParameters {
      * Set RoPE frequency scaling method (default: linear unless specified by the model).
      */
     public ModelParameters setRopeScaling(RopeScalingType type) {
-        parameters.put("--rope-scaling", String.valueOf(type.getId()));
+        parameters.put("--rope-scaling", type.getArgValue());
         return this;
     }
 
@@ -960,3 +960,5 @@ public final class ModelParameters extends CliParameters {
     }
 
 }
+
+

--- a/src/main/java/de/kherud/llama/args/PoolingType.java
+++ b/src/main/java/de/kherud/llama/args/PoolingType.java
@@ -2,20 +2,20 @@ package de.kherud.llama.args;
 
 public enum PoolingType {
 
-    UNSPECIFIED(-1),
-    NONE(0),
-    MEAN(1),
-    CLS(2),
-    LAST(3),
-    RANK(4);
+    UNSPECIFIED("unspecified"),
+    NONE("none"),
+    MEAN("mean"),
+    CLS("cls"),
+    LAST("last"),
+    RANK("rank");
 
-    private final int id;
+    private final String argValue;
 
-    PoolingType(int value) {
-        this.id = value;
+    PoolingType(String value) {
+        this.argValue = value;
     }
 
-    public int getId() {
-        return id;
+    public String getArgValue() {
+        return argValue;
     }
 }

--- a/src/main/java/de/kherud/llama/args/RopeScalingType.java
+++ b/src/main/java/de/kherud/llama/args/RopeScalingType.java
@@ -2,20 +2,20 @@ package de.kherud.llama.args;
 
 public enum RopeScalingType {
 
-    UNSPECIFIED(-1),
-    NONE(0),
-    LINEAR(1),
-    YARN2(2),
-    LONGROPE(3),
-    MAX_VALUE(3);
+    UNSPECIFIED("unspecified"),
+    NONE("none"),
+    LINEAR("linear"),
+    YARN2("yarn"),
+    LONGROPE("longrope"),
+    MAX_VALUE("maxvalue");
 
-    private final int id;
+    private final String argValue;
 
-    RopeScalingType(int value) {
-        this.id = value;
+    RopeScalingType(String value) {
+        this.argValue = value;
     }
 
-    public int getId() {
-        return id;
+    public String getArgValue() {
+        return argValue;
     }
 }


### PR DESCRIPTION
Most LLMs expect a string describing the pooling type and rope scaling type parameters, rather than an integer.
Previously, using integers resulted in unrecognized or invalid values.

This pull request corrects the issue by:
    - Updating the PoolingType and RopeScalingType enums to use string values instead of integers.
    - Adjusting their usage accordingly in the ModelParameters class.